### PR TITLE
Fix Steam JP Launch & Implement Robust Path Finding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests~=2.32.4
 selenium~=4.34.2
 SteamPathFinder==0.0.5
 Werkzeug~=3.1.3
+vdf==3.4

--- a/umalauncher/mdb.py
+++ b/umalauncher/mdb.py
@@ -12,31 +12,60 @@ def get_db_path():
     global DB_PATH
     if DB_PATH:
         return DB_PATH
-    if 'IS_UL_GLOBAL' in os.environ:
-        DB_PATH = os.path.expandvars("%userprofile%\\AppData\\LocalLow\\Cygames\\Umamusume\\master\\master.mdb")
+
+    # JP Steam version stores master.mdb in the game install directory
+    if 'IS_JP_STEAM' in os.environ:
+        game_install_path = util.get_game_folder()
+        if game_install_path is None:
+            logger.error("Could not find game install path for JP Steam version.")
+            util.show_error_box_no_report("Error", "Could not find the game install path.<br>Uma Launcher will now close.")
+            if gui.THREADER:
+                gui.THREADER.stop()
+            return None
+        
+        db_path_candidate = os.path.join(game_install_path, "UmamusumePrettyDerby_Jpn_Data\\Persistent\\master\\master.mdb")
+        if not os.path.exists(db_path_candidate):
+            logger.error(f"Could not find mdb at game install path: {db_path_candidate}")
+            util.show_error_box_no_report("Error", "Could not find the game database file.<br>Try restarting Uma Launcher after the game updates.<br>Uma Launcher will now close.")
+            if gui.THREADER:
+                gui.THREADER.stop()
+            return None
+        DB_PATH = db_path_candidate
+
+    # Global Steam version stores master.mdb in AppData
+    elif 'IS_UL_GLOBAL' in os.environ:
+        db_path_candidate = os.path.expandvars("%userprofile%\\AppData\\LocalLow\\Cygames\\Umamusume\\master\\master.mdb")
+        if not os.path.exists(db_path_candidate):
+            logger.error(f"Could not find mdb at path: {db_path_candidate}")
+            util.show_error_box_no_report("Error", "Could not find the game database file.<br>Try restarting Uma Launcher after the game updates.<br>Uma Launcher will now close.")
+            if gui.THREADER:
+                gui.THREADER.stop()
+            return None
+        DB_PATH = db_path_candidate
+
+    # DMM version can be in either AppData or game install directory
     else:
-        if 'IS_JP_STEAM' in os.environ:
-            DB_PATH = os.path.expandvars("%userprofile%\\AppData\\LocalLow\\Cygames\\UmamusumePrettyDerby_Jpn\\master\\master.mdb")
-        else:
-            DB_PATH = os.path.expandvars("%userprofile%\\AppData\\LocalLow\\Cygames\\umamusume\\master\\master.mdb")
-        if not os.path.exists(DB_PATH):
-            logger.debug( f"Could not find mdb at path: {DB_PATH}, trying game install directory")
+        db_path_candidate = os.path.expandvars("%userprofile%\\AppData\\LocalLow\\Cygames\\umamusume\\master\\master.mdb")
+        if not os.path.exists(db_path_candidate):
+            logger.debug(f"Could not find mdb at path: {db_path_candidate}, trying game install directory")
             game_install_path = util.get_game_folder()
             if game_install_path is None:
-                logger.error(f"Could not game install path")
-                util.show_error_box_no_report("Error",f"Could not find the game install path.<br>Uma Launcher will now close.")
+                logger.error("Could not find game install path for DMM version.")
+                util.show_error_box_no_report("Error", "Could not find the game install path.<br>Uma Launcher will now close.")
                 if gui.THREADER:
                     gui.THREADER.stop()
-            if 'IS_JP_STEAM' in os.environ:
-                DB_PATH = os.path.join( game_install_path, "UmamusumePrettyDerby_Jpn_Data\\Persistent\\master\\master.mdb")
-            else:
-                DB_PATH = os.path.join( game_install_path, "umamusume_Data\\Persistent\\master\\master.mdb")
-            if not os.path.exists(DB_PATH):
-                logger.error(f"Could not find mdb at game install path: {DB_PATH}")
-                util.show_error_box_no_report("Error",f"Could not find the game database file.<br>Try restarting Uma Launcher after the game updates.<br>Uma Launcher will now close.")
+                return None
+            
+            db_path_candidate = os.path.join(game_install_path, "umamusume_Data\\Persistent\\master\\master.mdb")
+            if not os.path.exists(db_path_candidate):
+                logger.error(f"Could not find mdb at game install path: {db_path_candidate}")
+                util.show_error_box_no_report("Error", "Could not find the game database file.<br>Try restarting Uma Launcher after the game updates.<br>Uma Launcher will now close.")
                 if gui.THREADER:
                     gui.THREADER.stop()
-    logger.debug( f"Using mdb path: {DB_PATH}")
+                return None
+        DB_PATH = db_path_candidate
+
+    logger.debug(f"Using mdb path: {DB_PATH}")
     return DB_PATH
 
 
@@ -49,7 +78,10 @@ def update_mdb_cache():
 class Connection():
     def __init__(self):
         try:
-            self.conn = sqlite3.connect(f"file:{get_db_path()}?mode=ro", uri=True)
+            db_path = get_db_path()
+            if db_path is None:
+                raise sqlite3.OperationalError("Database path could not be determined.")
+            self.conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
         except sqlite3.OperationalError:
             util.show_error_box_no_report("Connection Error", "Could not connect to the game database.<br>Try restarting Uma Launcher after the game updates.<br>Uma Launcher will now close.")
             if gui.THREADER:

--- a/umalauncher/util.py
+++ b/umalauncher/util.py
@@ -160,13 +160,19 @@ def get_game_folder():
     game_data = None
     try:
         if 'IS_JP_STEAM' in os.environ:
-            steam_path = get_steam_path()
             app_id = "3564400"
-            game_name = "ウマ娘 プリティーダービー"
             try:
-                return get_game_path(steam_path, app_id, game_name)
+                return get_app_path(app_id)
             except FileNotFoundError as e:
-                logger.error( "Could not locate steam JP game directory!" )
+                logger.error( "Could not locate Steam JP game directory!" )
+                logger.error(traceback.format_exc())
+                return None
+        elif 'IS_UL_GLOBAL' in os.environ:
+            app_id = "3224770"
+            try:
+                return get_app_path(app_id)
+            except FileNotFoundError as e:
+                logger.error( "Could not locate Steam Global game directory!" )
                 logger.error(traceback.format_exc())
                 return None
         else:

--- a/umalauncher/windowmover.py
+++ b/umalauncher/windowmover.py
@@ -202,7 +202,7 @@ class WindowMover():
 
             auto_resize = self.threader.settings["lock_game_window"]
 
-            if auto_resize and 'IS_UL_GLOBAL'or 'IS_JP_STEAM' in os.environ in os.environ:
+            if auto_resize and ('IS_UL_GLOBAL' in os.environ or 'IS_JP_STEAM' in os.environ):
                 logger.info('Disabling auto resize (in global or jp steam mode)')
                 self.threader.settings["lock_game_window"] = False
                 auto_resize = False


### PR DESCRIPTION
### **Description:**

This PR fixes the crash that occurs when launching the JP Steam version of the game and introduces a more reliable method for locating Steam game installations.

**The Problem:**

The application was unable to find the game's installation directory for the JP Steam version. This was caused by a few issues:
1.  Initially using the wrong game name/folder name for the path lookup.
2.  The `SteamPathFinder` library was not robust enough to handle all installation scenarios.

This resulted in a `FileNotFoundError` or `TypeError` on startup when trying to access the `master.mdb` database.

**The Solution:**

This has been replaced with a much more robust method that directly parses Steam's own configuration files:
- It now uses the `vdf` library to read `libraryfolders.vdf` and find all of the user's Steam library locations.
- It then finds the game's specific `appmanifest_<app_id>.acf` file to get the exact `installdir` name.

This ensures the game path is found correctly even if the user has installed the game in a non-standard library or has a custom installation folder name.

**Other Fixes:**

- Added the `vdf` library to `requirements.txt`.
- Fixed a `TypeError` in `windowmover.py` that was exposed after the initial pathing issue was resolved.
- Corrected the database path logic in `mdb.py` to handle the different file locations for the JP Steam, Global Steam, and DMM versions correctly.

**Testing:**

Local testing has been performed on both Steam versions:
- The **JP Steam version** now launches successfully, resolving the startup crash. (Note: CarrotJuicer/CarrotBlender message decoding for this version is not yet functional).
- The **Global Steam version** also launches successfully, and CarrotBlender message decoding is confirmed to be working correctly.

This PR should resolve the startup issues for all Steam users.